### PR TITLE
change class name to RubyBranchCoverage

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - lib/ruby_branch_cover/version.rb
+      - lib/ruby_branch_coverage/version.rb
 
 jobs:
   build:

--- a/lib/ruby_branch_coverage.rb
+++ b/lib/ruby_branch_coverage.rb
@@ -2,10 +2,10 @@
 
 require 'json'
 require 'builder'
-require_relative 'ruby_branch_cover/version'
-require_relative 'ruby_branch_cover/engine'
+require_relative 'ruby_branch_coverage/version'
+require_relative 'ruby_branch_coverage/engine'
 # Convert JSON to XML for branch coverage
-class RubyBranchCover
+class RubyBranchCoverage
   def read_json_and_getxml(filepath, parallelism_count, parallelism_processors = 0)
     file = File.read(filepath)
     data_hash = JSON.parse(file)

--- a/lib/ruby_branch_coverage/engine.rb
+++ b/lib/ruby_branch_coverage/engine.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # rubocop:disable Style/Documentation
-class RubyBranchCover
+class RubyBranchCoverage
   class Engine < ::Rails::Engine
-    isolate_namespace RubyBranchCover
+    isolate_namespace RubyBranchCoverage
   end
 end
 # rubocop:enable Style/Documentation

--- a/lib/ruby_branch_coverage/version.rb
+++ b/lib/ruby_branch_coverage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class RubyBranchCover
+class RubyBranchCoverage
   VERSION = '0.1.3'
 end

--- a/lib/tasks/simplecov.rake
+++ b/lib/tasks/simplecov.rake
@@ -28,7 +28,7 @@ namespace :simplecov do
                                                            SimpleCov::Formatter::JSONFormatter
                                                          ])
     end
-    ruby_branch = RubyBranchCover.new
+    ruby_branch = RubyBranchCoverage.new
     ruby_branch.read_json_and_getxml('coverage/.resultset.json', args[:parallelism].to_i)
   end
 end

--- a/ruby_branch_coverage.gemspec
+++ b/ruby_branch_coverage.gemspec
@@ -1,15 +1,15 @@
-require_relative 'lib/ruby_branch_cover/version'
+require_relative 'lib/ruby_branch_coverage/version'
 
 Gem::Specification.new do |s|
-    s.name        = 'ruby_branch_cover'
-    s.version     = RubyBranchCover::VERSION
+    s.name        = 'ruby_branch_coverage'
+    s.version     = RubyBranchCoverage::VERSION
     s.summary     = 'Branch Coverage Ruby!'
     s.description = 'A program to convert json to xml test coverage format gem'
     s.authors     = ['Suganya']
     s.email       = ['kuppusamy.suganya@moneyforward.co.jp']
     s.files = Dir["{config,lib}/**/*", "Rakefile"]
     s.homepage    =
-      'https://rubygems.pkg.github.com/moneyforward/ruby_branch_cover'
+      'https://rubygems.pkg.github.com/moneyforward/ruby_branch_coverage'
 
     s.metadata["allowed_push_host"] = 'https://rubygems.pkg.github.com'
     s.add_development_dependency "rspec-rails"

--- a/spec/lib/ruby_branch_coverage_spec.rb
+++ b/spec/lib/ruby_branch_coverage_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "ruby_branch_cover"
 
-RSpec.describe RubyBranchCover do
+RSpec.describe RubyBranchCoverage do
   it "check line already present in list of lineToCover element" do
     lineToCoverElement1 = {lineNumber:12 , covered: true , branchesToCover: 12, coveredBranches:12}
     lineToCoverElement2 = {lineNumber:34 , covered: false , branchesToCover: 3, coveredBranches:1}
@@ -10,7 +10,7 @@ RSpec.describe RubyBranchCover do
     lineArray.push(lineToCoverElement1)
     lineArray.push(lineToCoverElement2)
     lineArray.push(lineToCoverElement3)
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     index = c1format.send :check_for_duplicate_line, 34, lineArray
     expect(index).to eq 1
   end
@@ -23,7 +23,7 @@ RSpec.describe RubyBranchCover do
     lineArray.push(lineToCoverElement1)
     lineArray.push(lineToCoverElement2)
     lineArray.push(lineToCoverElement3)
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     index = c1format.send :check_for_duplicate_line, 55, lineArray
     expect(index).to eq -1
   end
@@ -34,50 +34,50 @@ RSpec.describe RubyBranchCover do
       "[:else, 2, 10, 12, 12, 15]": 20,
       "[:else, 3, 10, 12, 12, 15]": 0
     }
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     not_covered = c1format.send :find_notcovered_branches, conditionmap
     expect(not_covered).to eq 2
   end
 
   it "input json file and generate xml file" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset.json", 1)
     expect(output).to eq(true)
   end
 
   it "input json file and generate xml file with more than 1 parallel testing" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset4.json", 3)
     expect(output).to eq(true)
   end
 
   it "input empty json file and generate xml file" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset2.json", 1)
     expect(output).to eq(false)
   end
 
   it "input [no branches,only lines] json file and generate xml file" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset3.json", 1)
     expect(output).to eq(false)
   end
 
   # when run parallelism with multiple processors
   it "input json file (parallelism = 2 & processors = 3) and generate xml file" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset-multiple-processors2-3.json", 2, 3)
     expect(output).to eq(true)
   end
 
   it "input json file (parallelism = 3 & processors = 2) and generate xml file" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset-multiple-processors3-2.json", 3, 2)
     expect(output).to eq(true)
   end
 
   it "input json file (parallelism = 4 & processors = 4) and generate xml file" do
-    c1format = RubyBranchCover.new
+    c1format = RubyBranchCoverage.new
     output = c1format.read_json_and_getxml("spec/lib/upload/.resultset-multiple-processors4-4.json", 4, 4)
     expect(output).to eq(true)
   end


### PR DESCRIPTION
I did change the class name to RubyBranchCoverage because the repo name now is ruby_branch_coverage